### PR TITLE
Update cut01a.baf

### DIFF
--- a/arestorationp/baf/cut01a.baf
+++ b/arestorationp/baf/cut01a.baf
@@ -3,6 +3,9 @@ IF
 THEN
   RESPONSE #100
     CutSceneId("CSIren")
+    SetAreaScript("cutskip2",OVERRIDE)
+    SetGlobal("BD_CUTSCENE_BREAKABLE","GLOBAL",2)
+    SetCutSceneBreakable(TRUE)
     MoveViewPoint([2576.908],INSTANT)
     Wait(1)
     FadeFromColor([1.0],0)


### PR DESCRIPTION
The restored Promenade Cutscene was not skippable pressing "ESC" key.

I *know* that "I must suffer", but watching ALL the expanded cutscene every time with the game unresponsive (not alt+f4) was a bit too much :)

I just copy pasted the missing code portion from the vanilla script, tested in BG2EE, but should be fine in EET too.